### PR TITLE
Remove JQuery dependent code

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -39,7 +39,7 @@
         performActionWithoutTriggeringEvent: function(action) {
             var ignoring = this._state.ignoringEvents;
             this._state.ignoringEvents = true;
-            if($.isFunction(action)) {
+            if(typeof (action) === 'function') {
                 action();
             }
             this._state.ignoringEvents = ignoring;
@@ -126,18 +126,17 @@
             }
         },
         _setButtonDisabled: function(button, condition) {
-            var $button = $(button);
             var className = 'leaflet-disabled';
             if(condition) {
-                $button.addClass(className);
+                L.DomUtil.addClass(button, className);
             }
             else {
-                $button.removeClass(className);
+                L.DomUtil.removeClass(button, className);
             }
         },
         _pop: function(stack) {
             stack = stack.items;
-            if($.isArray(stack) && stack.length > 0) {
+            if(L.Util.isArray(stack) && stack.length > 0) {
                 return stack.splice(stack.length - 1, 1)[0];
             }
             return undefined;
@@ -145,7 +144,7 @@
         _push: function(stack, value) {
             var maxLength = this._state.maxMovesToSave;
             stack = stack.items;
-            if($.isArray(stack)) {
+            if(L.Util.isArray(stack)) {
                 stack.push(value);
                 if(maxLength > 0 && stack.length > maxLength) {
                     stack.splice(0, 1);
@@ -162,7 +161,7 @@
         },
         _popStackAndUseLocation : function(stackToPop, stackToPushCurrent) {
             //check if we can pop
-            if($.isArray(stackToPop.items) && stackToPop.items.length > 0) {
+            if(L.Util.isArray(stackToPop.items) && stackToPop.items.length > 0) {
                 var current = this._buildZoomCenterObjectFromCurrent(this._map);
                 //get most recent
                 var previous =  this._pop(stackToPop);


### PR DESCRIPTION
I discovered that leaflet-history depends on jQuery. I am using the angular-leaflet-directive and jQuery is not present here. So I rewrote 